### PR TITLE
ENG 1589 Update SDK delete workflow documentation

### DIFF
--- a/workflows/deleting-a-workflow.md
+++ b/workflows/deleting-a-workflow.md
@@ -31,7 +31,7 @@ flow = client.flow(workflow_id)
 flow.list_saved_objects()
 ```
 
-This returns a dictionary with the integration name as the key and the list of saved object names or paths as the values. You can pass this or any dictionary of the same format to the `delete_flow` method to delete the objects when deleting the flow. If any of them were saved with update mode append, you will additionally need to set `force=True` to confirm you understand the entire object would be deleted.
+This returns a dictionary with the integration name as the key and the list of saved object names or paths as the values. You can pass this or any dictionary of the same format to the `delete_flow` method to delete the objects when deleting the flow. If any of them were saved with update mode append, you will additionally need to set `force=True` to confirm you understand the entire object would be deleted, otherwise the whole workflow deletion will fail.
 
 ```python
 workflow_id = "0c007eff-6ae0-4a1a-a114-5f16164ffcdf" # Set your workflow ID here.

--- a/workflows/deleting-a-workflow.md
+++ b/workflows/deleting-a-workflow.md
@@ -31,7 +31,18 @@ flow = client.flow(workflow_id)
 flow.list_saved_objects()
 ```
 
-This returns a dictionary with the integration name as the key and the list of saved object names or paths as the values. You can pass this or any dictionary of the same format to the `delete_flow` method to delete the objects when deleting the flow. If any of them were saved with update mode append, you will additionally need to set `force=True` to confirm you understand the entire object would be deleted, otherwise the whole workflow deletion will fail.
+This returns a dictionary with the integration name as the key and the list of saved object names or paths as the values. For example, if the workflow wrote 3 tables, `table_1` and `table_2` in the `aqueduct_demo` integration and `table_1` in the `postgres` integration, `flow.list_saved_objects()` would return:
+
+```python
+{
+    "aqueduct_demo": ["table_1", "table_2"]
+    "postgres": ["table_1"]
+}
+```
+
+You can pass this or any dictionary of the same format to the `delete_flow` method to delete the objects when deleting the flow. Tables can be published either in `append`, `replace`, or `fail` mode (see [Relational Databases](integrations/using-integrations/relational-databases.md) for details). When tables are saved in `append` mode, Aqueduct cannot guarantee that there was not data previously set by Aqueduct that's stored in the table. To prevent any unintentional deletion of data, please set `force=True` when deleting a data that was created in append mode.
+
+The Aqueduct SDK will automatically prompt you to do this. It will not allow you to delete your workflow without the `force` flag.
 
 ```python
 workflow_id = "0c007eff-6ae0-4a1a-a114-5f16164ffcdf" # Set your workflow ID here.

--- a/workflows/deleting-a-workflow.md
+++ b/workflows/deleting-a-workflow.md
@@ -23,3 +23,19 @@ workflow_id = "0c007eff-6ae0-4a1a-a114-5f16164ffcdf" # Set your workflow ID here
 client.delete_flow(workflow_id)
 ```
 
+When deleting a workflow, you can additionally delete objects saved by the workflow. You can list the objects with the `list_saved_objects` method on the Flow object:
+
+```python
+workflow_id = "0c007eff-6ae0-4a1a-a114-5f16164ffcdf" # Set your workflow ID here.
+flow = client.flow(workflow_id)
+flow.list_saved_objects()
+```
+
+This returns a dictionary with the integration name as the key and the list of saved object names or paths as the values. You can pass this or any dictionary of the same format to the `delete_flow` method to delete the objects when deleting the flow. If any of them were saved with update mode append, you will additionally need to set `force=True` to confirm you understand the entire object would be deleted.
+
+```python
+workflow_id = "0c007eff-6ae0-4a1a-a114-5f16164ffcdf" # Set your workflow ID here.
+flow = client.flow(workflow_id)
+all_objects = flow.list_saved_objects()
+client.delete_flow(workflow_id, saved_objects_to_delete=all_objects, force=True)
+```


### PR DESCRIPTION
Delete workflow can now additionally delete saved objects. Update documentation accordingly.