### PR TITLE
Update the SQL query placeholder syntax documentation

### DIFF
--- a/parameters.md
+++ b/parameters.md
@@ -63,27 +63,35 @@ Types are also enforced on parameters. You cannot set a new value that is of a d
 
 #### Parameters in SQL Queries
 
-SQL queries are parameterized in a special way, using this double-bracket syntax:
+SQL queries are parameterized using the Postgres-inspired $1, $2, etc. placeholder syntax. The number after the dollar sign indicates which parameter to replace the placeholder with.
 
 ```python
 # A parameter used in a SQL query *must* be a string type.
-_ = client.create_param("country", default="Venezuela")
+country_param = client.create_param("country", default="Venezuela")
+limit_param = client.create_param("limit", default=10)
 
-# The value of `country_param` is interpolated into the double-bracketed placeholder.
+# The country is substituted into $1, whereas the limit parameter is substituted into $2.
 db = client.integration("aqueduct_demo")
-output_table = db.sql("select * from locations where country_name='{{country}}'")
+output_table = db.sql("select * from hotel_reviews where reviewer_nationality=' $1 ' limit $2", parameters=[country_param, limit_param])
 
-# This returns the result of `select * from locations where country_name='Venezuela';`
+# This returns the result of `select * from hotel_reviews where where reviewer_nationality=' Venezuela ' limit 10;`
 output_table.get()
 
-# This returns the result of `select * from locations where country_name='Argentina';`
-output_table.get(parameters={"country": "Argentina"})
+# This returns the result of `select * from hotel_reviews where reviewer_nationality=' Argentina ' limit 50;`
+output_table.get(parameters={"country": "Argentina", "limit": "50"})
 ```
 
 {% hint style="info" %}
-We perform a direct substitute of the parameter string into the double-bracketed placeholder token, so it is still up to you to construct your SQL query appropriately. For example, we do not automatically add quotes around column names for you.
+We perform a direct substitute of the parameter string into the $-placeholder token, so it is still up to you to construct your SQL query appropriately. For example, we do not automatically add quotes around column names for you.
 {% endhint %}
 
-We provide the following built-in SQL parameters:
+We also provide the following built-in SQL parameters:
 
 * `today`: expands to a string date in the format `'%Y-%m-%d'`. Eg. `SELECT * from hotel_reviews WHERE review_date={{today}};`
+
+In order to use the built-in parameters, you must use the `{{ }}` syntax. For example:
+
+```python
+reviews_before_today = db.sql("select * from hotel_reviews where review_date < {{ today }}")
+reviews_before_today.get()
+```


### PR DESCRIPTION
The example notebooks have already been fixed. Need to update this parameter guide page to use $1, $2 instead of {{ ...}}