### PR TITLE
add links to top-level "Installation and Configuration" page

### DIFF
--- a/installation-and-configuration/README.md
+++ b/installation-and-configuration/README.md
@@ -11,10 +11,10 @@ For more details installing Aqueduct in different environments, see:
 
 * [installing-aqueduct](installing-aqueduct/ "mention")
 * [running-on-aws-ec2.md](installing-aqueduct/running-on-aws-ec2.md "mention")
-* Running on Google Compute Engine (TODO link me)
-* Running on Kubernetes with Helm
+* [running-on-google-compute-engine.md](installing-aqueduct/running-on-google-compute-engine.md "mention")
+* [deploying-with-helm.md](installing-aqueduct/deploying-with-helm.md "mention")
 
-Aqueduct comes with simple default configurations but is highly customizable. See Configuring Aqueduct (TODO link me) for more details, including:
+Aqueduct comes with simple default configurations but is highly customizable. See [configuring-aqueduct.md](configuring-aqueduct.md "mention") for more details, including:
 
 * installing resource dependencies
 * accessing Aqueduct externally


### PR DESCRIPTION
## Summary

Add some missing sub-links to the "Installation and Configuration" page

## Details

- update TODOs with links to GCE and Configuring page
- add link to Helm page as well