### PR TITLE
fix various typos

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -23,7 +23,7 @@
 * [Workflows](workflows/README.md)
   * [Creating a Workflow](workflows/creating-a-workflow.md)
   * [Workflow Versions](workflows/workflow-versions.md)
-  * [Scheduling Workflwos](workflows/managing-workflow-schedules.md)
+  * [Scheduling Workflows](workflows/managing-workflow-schedules.md)
   * [Editing a Workflow](workflows/editing-a-workflow.md)
   * [Deleting a Workflow](workflows/deleting-a-workflow.md)
 * [Resources](resources/README.md)

--- a/metrics-and-checks.md
+++ b/metrics-and-checks.md
@@ -2,5 +2,5 @@
 
 In addition to providing a simple API to define and publish workflows, Aqueduct makes it easy for you to monitor your workflows once they have been created. There are two key mechanisms by which you can monitor your workflows:
 
-* [**Metrics**](metrics-and-checks/metrics-measuring-your-predictions.md):allow you to measure your workflows by computing a numerical value over an Artifact ( or other metrics).
-* [**Checks**](metrics-and-checks/checks-ensuring-correctness.md):allow you to ensure the correctness of your workflow by taking in one or more Artifacts and Metrics and returning a boolean value indicating the correctness of the workflow.
+* [**Metrics**](metrics-and-checks/metrics-measuring-your-predictions.md): allow you to measure your workflows by computing a numerical value over an Artifact (or other metrics).
+* [**Checks**](metrics-and-checks/checks-ensuring-correctness.md): allow you to ensure the correctness of your workflow by taking in one or more Artifacts and Metrics and returning a boolean value indicating the correctness of the workflow.

--- a/quickstart-guide.md
+++ b/quickstart-guide.md
@@ -33,7 +33,7 @@ Note that the API key associated with the server can also be found in the output
 
 ### Accessing Data
 
-The base data for our workflow is the [hotel reviews dataset](resources/data-systems/aqueduct-demo-resource.md)) in the pre-built aqueduct\_demo that comes with the Aqueduct server. This code does two things -- (1) it loads a connection to the demo database, and (2) it runs a SQL query against that DB and returns a pointer to the resulting dataset.
+The base data for our workflow is the [hotel reviews dataset](resources/data-systems/aqueduct-demo-resource.md) in the pre-built aqueduct\_demo that comes with the Aqueduct server. This code does two things -- (1) it loads a connection to the demo database, and (2) it runs a SQL query against that DB and returns a pointer to the resulting dataset.
 
 ```python
 demo_db = client.resource("aqueduct_demo")
@@ -59,7 +59,7 @@ def transform_data(reviews):
     '''
     This simple Python function takes in a DataFrame with hotel reviews
     and adds a column called strlen that has the string length of the
-    review.    
+    review.
     '''
     reviews['strlen'] = reviews['review'].str.len()
     return reviews


### PR DESCRIPTION
## Summary

Just some typos I found while reading the docs

## Details

- "Workflwos" -> "Workflows"
- add missing space, remove unnecessary space
- remove extra closing paren