### PR TITLE
add missing links to Summary and Data Systems

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -63,6 +63,7 @@
   * [requirements.txt](operators/specifying-a-requirements.txt.md)
   * [File Dependencies](operators/file-dependencies-in-python.md)
   * [Configuring GPUs, CPUs, and Memory](operators/configuring-resource-constraints.md)
+  * [Lazy vs Eager Execution](operators/lazy-vs-eager-execution.md)
   * [LLMs](operators/llms.md)
 * [Artifacts](artifacts.md)
 * [Parameters](parameters.md)
@@ -122,4 +123,5 @@
 * [Guides](guides/README.md)
   * [Porting a workflow to Aqueduct](guides/porting-a-workflow-to-aqueduct.md)
   * [Debugging a Failed Workflow](guides/debugging-a-failed-workflow.md)
+  * [Conquering the Python Environment](guides/conquering-the-python-environment.md)
 * [FAQs](faqs.md)

--- a/resources/data-systems/README.md
+++ b/resources/data-systems/README.md
@@ -18,6 +18,7 @@ Here are the systems Aqueduct supports:
   * [aws-redshift.md](sql-systems/aws-redshift.md "mention")
   * [google-bigquery.md](sql-systems/google-bigquery.md "mention")
 * [non-sql-systems](non-sql-systems/ "mention")&#x20;
+  * [aws-s3.md](non-sql-systems/aws-s3.md "mention")
   * [google-cloud-storage.md](non-sql-systems/google-cloud-storage.md "mention")
   * [mongodb.md](non-sql-systems/mongodb.md "mention")
   * DynamoDB _(coming soon!)_


### PR DESCRIPTION
## Summary

Noticed there were some missing links in a few places

## Details

- Summary was missing two links:
  - "Lazy vs Eager Execution", which had a few links to it - those links ended up directing to the source code of the GitBook directly instead of the rendered docs (see screenshot)
  - "Conquering the Python Environment", which seemed to have no links to it
    - discovered it while editing the docs myself and noticing that it was missing from the Summary
- Data Systems was missing an S3 link

### Screenshot

Of a link going to source instead of rendered docs -- see bottom left linking to GitHub directly:
![Screen Shot 2023-07-04 at 8 39 07 PM](https://github.com/aqueducthq/gitbook/assets/4970083/7c1b5e47-d638-478f-be62-68009229f30b)

## Future Work(?)

The top-level README is also missing some links, but not sure if that is intentional or not. As in, if it only has a selection of links intentionally.
- Installation docs, LLM SDK, Notifications, etc are not linked to from the README

Some examples from [the main source repo](https://github.com/aqueducthq/aqueduct/tree/main/examples) seem to be missing as well. Similarly not sure if that is intentional or not
- Resnet, March Madness, etc are not in the example workflows
